### PR TITLE
adding Eclipse Maven Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ To install from source use the provided [just](https://github.com/casey/just) re
 ❯ just install-debug
 ```
  
+## Initializing Projects
 
+If you are using Maven for your Java Project, you have to initialize your project for Eclipse JDT using:
+```shell
+❯ mvn eclipse:eclipse 
+```
+
+Without initializing your project, Eclipse JDT won't work.
  
 ## Licence
 


### PR DESCRIPTION
Eclipse JDT is not working because your project does not resolve to a ICompilationUnit.

The exact error in Lapce is:

```
[2023-06-14][15:53:29][lapce_data::proxy][ERROR] Jun 14, 2023, 3:53:29 PM file:///path/to/App.java does not resolve to a ICompilationUnit
```

This is fixed by running
```shell
mvn eclipse:eclipse
```
